### PR TITLE
Use '=' to avoid errors.

### DIFF
--- a/manifests/runner.pp
+++ b/manifests/runner.pp
@@ -27,7 +27,7 @@ define gitlab_ci_runner::runner (
   $_config = merge($_default_config, $config)
 
   # Convert configuration into a string
-  $parameters_array = join_keys_to_values($_config, ' ')
+  $parameters_array = join_keys_to_values($_config, '=')
   $parameters_array_dashes = prefix($parameters_array, '--')
   $parameters_string = join($parameters_array_dashes, ' ')
 


### PR DESCRIPTION
In current versions of the runner, using a space to join values and keys throws an error:
```
WARN[0000] boolean parameters must be passed in the command line with --cache-s3-insecure=true 
```
A solution is to replace the spaces with `=` signs.

This works as far as I have tested in my environment.